### PR TITLE
Trim whitespace in form submission validation

### DIFF
--- a/business-contact-form/backend/form-submission/package.json
+++ b/business-contact-form/backend/form-submission/package.json
@@ -4,7 +4,7 @@
   "description": "Lambda function for handling contact form submissions",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/validateFormData.test.js"
   },
   "dependencies": {
     "aws-sdk": "^2.1048.0",

--- a/business-contact-form/backend/form-submission/test/validateFormData.test.js
+++ b/business-contact-form/backend/form-submission/test/validateFormData.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const { validateFormData } = require('../app');
+
+// Test that validateFormData trims whitespace and accepts valid emails with spaces
+const data = { name: 'John Doe', email: 'test@example.com ', message: 'Hello' };
+const result = validateFormData(data);
+
+assert.strictEqual(result.isValid, true, 'Expected validation to pass');
+assert.deepStrictEqual(result.errors, {}, 'Expected no validation errors');
+assert.strictEqual(data.email, 'test@example.com', 'Expected email to be trimmed');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- sanitize required fields in `form-submission` Lambda to trim whitespace before validation
- export validator and add minimal dependency stubs for test environment
- add unit test for email trimming and wire into `npm test`

## Testing
- `cd business-contact-form/backend/form-submission && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e75469088321a6a6412a265bf622