### PR TITLE
feat: sanitize form inputs

### DIFF
--- a/business-contact-form/backend/form-submission/app.js
+++ b/business-contact-form/backend/form-submission/app.js
@@ -32,6 +32,23 @@ const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
 const SUBMISSIONS_TABLE = process.env.SUBMISSIONS_TABLE;
 
 /**
+ * Sanitizes user input by stripping HTML tags and escaping special characters
+ * @param {string} input - Raw user input
+ * @returns {string} - Sanitized string safe for storage and emails
+ */
+const sanitizeInput = (input = '') => {
+  return String(input)
+    // Remove HTML tags
+    .replace(/<[^>]*>/g, '')
+    // Escape special characters
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+
+/**
  * Validates the form submission data
  * @param {Object} data - The form submission data
  * @returns {Object} - Validation result with isValid and errors
@@ -44,7 +61,7 @@ const validateFormData = (data) => {
   if (!name) {
     errors.name = 'Name is required';
   } else {
-    data.name = name;
+    data.name = sanitizeInput(name);
   }
 
   // Validate email
@@ -53,7 +70,7 @@ const validateFormData = (data) => {
   if (!email || !emailRegex.test(email)) {
     errors.email = 'Valid email is required';
   } else {
-    data.email = email;
+    data.email = sanitizeInput(email);
   }
 
   // Validate message
@@ -61,7 +78,15 @@ const validateFormData = (data) => {
   if (!message) {
     errors.message = 'Message is required';
   } else {
-    data.message = message;
+    data.message = sanitizeInput(message);
+  }
+
+  // Sanitize optional fields
+  if (data.phone) {
+    data.phone = sanitizeInput(data.phone.trim());
+  }
+  if (data.company) {
+    data.company = sanitizeInput(data.company.trim());
   }
 
   return {

--- a/business-contact-form/backend/form-submission/test/validateFormData.test.js
+++ b/business-contact-form/backend/form-submission/test/validateFormData.test.js
@@ -9,4 +9,20 @@ assert.strictEqual(result.isValid, true, 'Expected validation to pass');
 assert.deepStrictEqual(result.errors, {}, 'Expected no validation errors');
 assert.strictEqual(data.email, 'test@example.com', 'Expected email to be trimmed');
 
+// Test that user input is sanitized
+const malicious = {
+  name: '<b>Jane</b>',
+  email: 'evil@example.com',
+  phone: '<script>alert(1)</script>',
+  company: 'ACME>',
+  message: 'Hello & welcome'
+};
+
+validateFormData(malicious);
+
+assert.strictEqual(malicious.name, 'Jane');
+assert.strictEqual(malicious.phone, 'alert(1)');
+assert.strictEqual(malicious.company, 'ACME&gt;');
+assert.strictEqual(malicious.message, 'Hello &amp; welcome');
+
 console.log('All tests passed');

--- a/business-contact-form/frontend/package.json
+++ b/business-contact-form/frontend/package.json
@@ -6,7 +6,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "axios": "^1.3.4"
+    "axios": "^1.3.4",
+    "dompurify": "^3.0.6"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/business-contact-form/frontend/src/components/ContactForm.js
+++ b/business-contact-form/frontend/src/components/ContactForm.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import axios from 'axios';
+import DOMPurify from 'dompurify';
 import './ContactForm.css';
 
 // This would be replaced with the actual API endpoint from CloudFormation output
@@ -68,7 +69,15 @@ const ContactForm = () => {
     setSubmitStatus(null);
     
     try {
-      const response = await axios.post(API_ENDPOINT, formData);
+      const sanitizedData = {
+        name: DOMPurify.sanitize(formData.name),
+        email: DOMPurify.sanitize(formData.email),
+        phone: DOMPurify.sanitize(formData.phone),
+        company: DOMPurify.sanitize(formData.company),
+        message: DOMPurify.sanitize(formData.message)
+      };
+
+      const response = await axios.post(API_ENDPOINT, sanitizedData);
       
       setSubmitStatus({
         type: 'success',


### PR DESCRIPTION
## Summary
- sanitize server-side submission fields before storing or emailing
- sanitize form data in the browser with DOMPurify
- add tests to cover sanitization logic

## Testing
- `CI=true npm test -- --passWithNoTests` (frontend)
- `cd business-contact-form/backend/form-submission && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e9c44ba8832189ac38dd431e4cdf