### PR TITLE
Restrict CORS to official domain

### DIFF
--- a/business-contact-form/backend/admin-get-submissions/app.js
+++ b/business-contact-form/backend/admin-get-submissions/app.js
@@ -82,7 +82,7 @@ exports.lambdaHandler = async (event, context) => {
       statusCode: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
+        'Access-Control-Allow-Origin': 'https://thunk-it.com'
       },
       body: JSON.stringify(result)
     };
@@ -94,7 +94,7 @@ exports.lambdaHandler = async (event, context) => {
       statusCode: 500,
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
+        'Access-Control-Allow-Origin': 'https://thunk-it.com'
       },
       body: JSON.stringify({
         message: 'Internal server error'

--- a/business-contact-form/backend/admin-update-submission/app.js
+++ b/business-contact-form/backend/admin-update-submission/app.js
@@ -69,7 +69,7 @@ exports.lambdaHandler = async (event, context) => {
         statusCode: 400,
         headers: {
           'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*'
+          'Access-Control-Allow-Origin': 'https://thunk-it.com'
         },
         body: JSON.stringify({
           message: 'Timestamp query parameter is required'
@@ -85,7 +85,7 @@ exports.lambdaHandler = async (event, context) => {
       statusCode: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
+        'Access-Control-Allow-Origin': 'https://thunk-it.com'
       },
       body: JSON.stringify({
         message: 'Submission updated successfully',
@@ -100,7 +100,7 @@ exports.lambdaHandler = async (event, context) => {
       statusCode: error.message.includes('required') || error.message.includes('Invalid') ? 400 : 500,
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
+        'Access-Control-Allow-Origin': 'https://thunk-it.com'
       },
       body: JSON.stringify({
         message: error.message || 'Internal server error'

--- a/business-contact-form/backend/form-submission/app.js
+++ b/business-contact-form/backend/form-submission/app.js
@@ -213,7 +213,7 @@ exports.lambdaHandler = async (event, context) => {
         statusCode: 400,
         headers: {
           'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*'
+          'Access-Control-Allow-Origin': 'https://thunk-it.com'
         },
         body: JSON.stringify({
           message: 'Validation failed',
@@ -233,7 +233,7 @@ exports.lambdaHandler = async (event, context) => {
       statusCode: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
+        'Access-Control-Allow-Origin': 'https://thunk-it.com'
       },
       body: JSON.stringify({
         message: 'Form submission successful',
@@ -248,7 +248,7 @@ exports.lambdaHandler = async (event, context) => {
       statusCode: 500,
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*'
+        'Access-Control-Allow-Origin': 'https://thunk-it.com'
       },
       body: JSON.stringify({
         message: 'Internal server error'

--- a/business-contact-form/template.yaml
+++ b/business-contact-form/template.yaml
@@ -32,7 +32,7 @@ Resources:
       Cors:
         AllowMethods: "'POST, GET, OPTIONS'"
         AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-        AllowOrigin: "'*'"
+        AllowOrigin: "'https://thunk-it.com'"
 
   # Lambda Functions
   FormSubmissionFunction:


### PR DESCRIPTION
## Summary
- lock API Gateway CORS origin to `https://thunk-it.com`
- update Lambda responses to return the official domain in `Access-Control-Allow-Origin`

## Testing
- `npm test` (from `backend/form-submission`)
- `node -e "const handler=require('./backend/form-submission/app').lambdaHandler; const event={body:'{}'}; handler(event,{}).then(r=>console.log(r.headers));"`

------
https://chatgpt.com/codex/tasks/task_e_6895e9c696b4832192082a4aa34b8848